### PR TITLE
fix the weird extra spacing

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -16,9 +16,7 @@
           class="panel-block is-active"
           v-for="item in historyReversed"
           @click="itemClicked(item)">
-          <pre>
-            {{'\n' + item.text}}
-          </pre>
+          <pre>{{item.text}}</pre>
           <br />
           <small>{{item.clipped}}</small>
         </a>


### PR DESCRIPTION
Instead of always adding a new line, let's fix the actual problem.
The "weird" extra spacing in the `<pre>` tag was coming from the formatted html (see the highlighted preceeded whitespace)

![](http://d.rbn.nu/WtR9pY.pnv)

Love the livestreams!